### PR TITLE
A primitive support for macOS build script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,16 @@ function(config_platform TARGET_NAME)
             -static-libstdc++
             -static-libgcc
         )
+    elseif(CMAKE_SYSTEM_NAME MATCHES "Darwin") # macOS
+        target_compile_definitions(${TARGET_NAME} PRIVATE
+            -D__APPLE__
+        )
+        target_link_libraries(${TARGET_NAME} PRIVATE
+            "-framework Cocoa" # For GUI
+            "-framework IOKit" # Optional: For hardware interaction
+            "-framework CoreFoundation" # Core macOS utilities
+            "-framework Carbon" # Legacy support if required
+        )
     else()
         message("${CMAKE_SYSTEM_NAME} enviroment for ${TARGET_NAME} not supported!")
     endif()
@@ -32,6 +42,9 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
         set(FIND_LIBRARY_USE_LIB64_PATHS OFF)
         set(CMAKE_IGNORE_PATH /lib /usr/lib /usr/local/lib /usr/lib/x86_64-linux-gnu)
         set(wxUSE_LIBJPEG OFF)
+    endif()
+    if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+        set(CMAKE_OSX_DEPLOYMENT_TARGET "10.14") # Minimum macOS version
     endif()
 endif()
 
@@ -46,7 +59,12 @@ set(INGORED_WARNINGS  "-Wno-unused-command-line-argument -Wno-deprecated-declara
 )
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${INGORED_WARNINGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${INGORED_WARNINGS}")
-add_subdirectory(${WXWIDGETS_CODE_DIR})
+
+if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+else()
+    add_subdirectory(${WXWIDGETS_CODE_DIR})
+endif()
+
 
 # define wxwidgets xrc
 set(wxrc $<TARGET_FILE:wxrc>)
@@ -82,10 +100,31 @@ add_executable(${PROJECT_NAME}
 target_include_directories(${PROJECT_NAME} PRIVATE
     ${LUA_CODE_DIR}/src
 )
-target_link_libraries(${PROJECT_NAME} PRIVATE
-    lua
-    wx::core 
-    wx::base
-    wx::propgrid
-)
+
+if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+    # Find wxWidgets
+    find_package(wxWidgets REQUIRED COMPONENTS core base)
+    # Include wxWidgets' settings (e.g., include directories, flags)
+    include(${wxWidgets_USE_FILE})
+    # Find wxWidgets
+    find_package(wxWidgets REQUIRED COMPONENTS core base propgrid)
+
+    if(wxWidgets_FOUND)
+        include(${wxWidgets_USE_FILE})
+        target_link_libraries(${PROJECT_NAME} PRIVATE ${wxWidgets_LIBRARIES})
+    else()
+        message(FATAL_ERROR "wxWidgets not found!")
+    endif()
+    target_link_libraries(${PROJECT_NAME} PRIVATE
+        lua
+    )
+else()
+    target_link_libraries(${PROJECT_NAME} PRIVATE
+        lua
+        wx::base
+        wx::propgrid
+    )
+endif()
+
+
 config_platform(${PROJECT_NAME})

--- a/Readme.md
+++ b/Readme.md
@@ -328,6 +328,28 @@ export DOCKER_ARCH=armhf BUILD_DIR=build_linuxa32_docker BUILD_TYPE=MinSizeRel U
 export DOCKER_ARCH=aarch64 BUILD_DIR=build_linuxa64_docker BUILD_TYPE=MinSizeRel USE_BUILDX=1 && bash script/build_docker.sh
 ```
 
+### (3) macOS
+``` sh
+
+# install Xcode Command Line Tools
+xcode-select --install
+
+# install Homebrew
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+# install dependency using Homebrew
+brew install wxwidgets
+brew install p7zip
+brew install gtk+3
+brew install cmake
+
+git clone https://github.com/YuriSizuku/TileViewer.git
+cd TileViewer
+chmod +x script/*.sh
+./script/build_macos.sh
+
+```
+
 ## Roadmap
 
 * Core

--- a/script/build_macos.sh
+++ b/script/build_macos.sh
@@ -1,0 +1,21 @@
+# default for mingw64
+if [ -z "$CC" ]; then CC=clang; fi
+if [ -z "$CXX" ]; then CXX=clang++; fi
+if [ -z "$BUILD_DIR" ]; then BUILD_DIR=$(pwd)/build_darwin; fi
+if [ -z "$BUILD_TYPE" ]; then BUILD_TYPE=Debug; fi
+
+# CORE_NUM=$(cat /proc/cpuinfo | grep -c ^processor)
+echo "## CC=$CC BUILD_DIR=$BUILD_DIR BUILD_TYPE=$BUILD_TYPE"
+
+# fetch depends
+mkdir -p depend
+source script/fetch_depend.sh
+fetch_lua
+fetch_wxwidgets
+
+# build project
+cmake -G "Unix Makefiles" -B $BUILD_DIR \
+    -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+    -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX
+    
+make -C $BUILD_DIR -j8

--- a/script/build_macos.sh
+++ b/script/build_macos.sh
@@ -11,7 +11,6 @@ echo "## CC=$CC BUILD_DIR=$BUILD_DIR BUILD_TYPE=$BUILD_TYPE"
 mkdir -p depend
 source script/fetch_depend.sh
 fetch_lua
-fetch_wxwidgets
 
 # build project
 cmake -G "Unix Makefiles" -B $BUILD_DIR \


### PR DESCRIPTION
I tried to modify some code to support build on macOS. 

The wxWidgets source code version doesn't build on the latest macOS Sequoia, because it uses an obsolete macOS API, so I changed that to use the homebrew installed version.

Currently building universal binary for both x86 and arm64 are not supported, I need to change the way how Lua builds in order to support that.

And yeah of course, cross-compiling for macOS isn't an option due to how Apple insists their SDK is only available on macOS.

Hopefully this doesn't affect Linux or other OS. And I hope you like it.
很抱歉，我就做了一点微小的工作，谢谢大家。